### PR TITLE
Adding comment to grouping example

### DIFF
--- a/flutter_local_notifications/README.md
+++ b/flutter_local_notifications/README.md
@@ -279,6 +279,7 @@ await flutterLocalNotificationsPlugin.show(
     secondNotificationPlatformSpecifics);
 
 // create the summary notification required for older devices that pre-date Android 7.0 (API level 24)
+// this is required is regardless of which versions of Android your application is going to support
 List<String> lines = List<String>();
 lines.add('Alex Faarborg  Check this out');
 lines.add('Jeff Chang    Launch Party');


### PR DESCRIPTION
Adding comment to grouping example to remark that the summary notification is required

As this repository hosts two packages, please ensure the PR title starts with the name of the package that it relates to using square brackets (e.g. [flutter_local_notifications])
